### PR TITLE
Remove redundant relative path import.

### DIFF
--- a/ln2sql/ln2sql_gui.py
+++ b/ln2sql/ln2sql_gui.py
@@ -3,7 +3,6 @@ import tkinter.filedialog
 from tkinter import *
 from tkinter.messagebox import *
 
-from .ln2sql import Ln2sql
 
 
 class App:


### PR DESCRIPTION
Using Python3 

python ln2sql/ln2sql_gui.py

```
ImportError: attempted relative import with no known parent package
```
Removing this import worked.